### PR TITLE
Added -b, --browser option

### DIFF
--- a/bin/exp.js
+++ b/bin/exp.js
@@ -12,11 +12,13 @@ commander.command('play')
   .description('launch a player app in your local browser on a player')
   .option('-p, --port [port]', 'the port to run on (8899)', parseInt)
   .option('-e, --host [host]', 'the player host (https://player.goexp.io)')
+  .option('-b, --browser [browser name]', 'the non-default browser name to launch')
   .action(function (env) {
     var options = {};
     options.path = './';
     options.host = env.host || 'https://player.goexp.io';
     options.port = env.port || 8899;
+    options.browser = env.browser || '';
     devPlayer.start(options);
   });
 

--- a/lib/dev-player/index.js
+++ b/lib/dev-player/index.js
@@ -37,7 +37,7 @@ module.exports = {
     server.listen(options.port);
 
     // Open in browser.
-    open('http://localhost:' + options.port);
+    open('http://localhost:' + options.port, options.browser);
     
     // Send refresh event down socket.
     watch.createMonitor(options.path, function (monitor) {


### PR DESCRIPTION
Allows for passing in a new argument for exp play. Example:  exp play
-b “Google Chrome”   This allows for targeting the users non-default
browser when using exp play to spawn the browser window.